### PR TITLE
[FIX] campo faltando no registro E116

### DIFF
--- a/sped/efd/icms_ipi/registros.py
+++ b/sped/efd/icms_ipi/registros.py
@@ -2129,6 +2129,7 @@ class RegistroE116(Registro):
         Campo(7, 'IND_PROC'),
         Campo(8, 'PROC'),
         Campo(9, 'TXT_COMPL'),
+        Campo(10, 'MES_REF'),
     ]
 
 


### PR DESCRIPTION
Segundo o manual que se encontra no [site](http://sped.rfb.gov.br/estatico/0D/2DC4C346EDFCDFAFA26C391C7398D060594B50/GUIA%20PR%C3%81TICO%20DA%20EFD%20-%20Vers%C3%A3o%202.0.22.pdf) da receita federal o registro E116 deve possuir o campo MES_REF.