### PR TITLE
o RegistroC100 do ICMS agora tb contempla a NFC-e

### DIFF
--- a/sped/efd/icms_ipi/registros.py
+++ b/sped/efd/icms_ipi/registros.py
@@ -299,7 +299,7 @@ class RegistroC001(Registro):
 
 class RegistroC100(Registro):
     """
-    DADOS NOTA FISCAL (CÓDIGO 01, 1B, 04 E 55)
+    DADOS NOTA FISCAL (CÓDIGO 01, 1B, 04, 55 E 65)
     """
     campos = [
         CampoFixo(1, 'REG', 'C100'),


### PR DESCRIPTION
Ola, obrigado pelo excelente trabalho.
Lendo as especificaçoes, vejo que a descriçao do RegistroC100 esta incompleta, pois a NFC-e (modelo 65) agora entra nesse registro tb. Isso pode ser visto na pagina 39 da especificaçao https://www.fazenda.sp.gov.br/sped/downloads/GUIA_PRATICO_DA_EFD-Versao_2.0.19.pdf

Minha empresa, a AKRETION, vai logo contribuir um modulo para o ERP open source Odoo para auxiliar a produzir o SPED no Odoo direitamente, foi na hora de verificar que nem todos documentos fiscais iriam nas mesmas tabelas do SPED que me deparei com esse detalhe da NFC-e...